### PR TITLE
Cleaning up code and fixing normalize

### DIFF
--- a/lib/bento/common.rb
+++ b/lib/bento/common.rb
@@ -107,19 +107,12 @@ module Common
         case tool
         when /parallels/
           ver = cmd.stdout.split(' ')[2]
-          # hash = cmd.stdout.split(' ')[3]
-          # ver = "#{semver} #{hash}"
         when /fusion/
           ver = cmd.stderr.split(' ')[5]
-          # hash = cmd.stderr.split(' ')[6].gsub(/^build-/,'')
-          # ver = "#{semver} \(#{hash}\)"
         when /vagrant/
-          semver = cmd.stdout.split(' ')[1]
-          ver = "#{semver}"
+          ver = cmd.stdout.split(' ')[1]
         when /virtualbox/
           ver = cmd.stdout.split('r')[0]
-          # hash = cmd.stdout.split('r')[1].gsub(/\n/,'')
-          # ver = "#{semver} \(#{hash}\)"
         else
           ver = cmd.stdout.split("\n")[0]
         end
@@ -131,34 +124,3 @@ module Common
     tool_versions
   end
 end
-
-# module PackerExec
-
-#   def for_packer_run_with(template)
-#     Tempfile.open("#{template}-metadata.json") do |md_file|
-#       Tempfile.open("#{template}-metadata-var-file") do |var_file|
-#         write_box_metadata(template, md_file)
-#         yield md_file, var_file
-#       end
-#     end
-#   end
-
-#   def write_box_metadata(template, io)
-#     md = BuildMetadata.new(template, build_timestamp, override_version).read
-#     io.write(JSON.pretty_generate(md))
-#     io.close
-#   end
-
-#   # def write_var_file(template, md_file, io)
-#   #   md = BuildMetadata.new(template, build_timestamp, override_version).read
-
-#   #   io.write(JSON.pretty_generate({
-#   #     box_basename:     md[:box_basename],
-#   #     build_timestamp:  md[:build_timestamp],
-#   #     git_revision:     md[:git_revision],
-#   #     metadata:         md_file.path,
-#   #     version:          md[:version],
-#   #   }))
-#   #   io.close
-#   # end
-# end

--- a/lib/bento/packerexec.rb
+++ b/lib/bento/packerexec.rb
@@ -5,6 +5,7 @@ module PackerExec
     Tempfile.open("#{template}-metadata.json") do |md_file|
       Tempfile.open("#{template}-metadata-var-file") do |var_file|
         write_box_metadata(template, md_file)
+        write_var_file(template, md_file, var_file)
         yield md_file, var_file
       end
     end
@@ -16,16 +17,16 @@ module PackerExec
     io.close
   end
 
-  # def write_var_file(template, md_file, io)
-  #   md = BuildMetadata.new(template, build_timestamp, override_version).read
+  def write_var_file(template, md_file, io)
+    md = BuildMetadata.new(template, build_timestamp, override_version).read
 
-  #   io.write(JSON.pretty_generate({
-  #     box_basename:     md[:box_basename],
-  #     build_timestamp:  md[:build_timestamp],
-  #     git_revision:     md[:git_revision],
-  #     metadata:         md_file.path,
-  #     version:          md[:version],
-  #   }))
-  #   io.close
-  # end
+    io.write(JSON.pretty_generate({
+      box_basename:     md[:box_basename],
+      build_timestamp:  md[:build_timestamp],
+      git_revision:     md[:git_revision],
+      metadata:         md_file.path,
+      version:          md[:version],
+    }))
+    io.close
+  end
 end


### PR DESCRIPTION
- uncommented `write_var_file` and added back to fix normalize
- cleaned up comments in code

Can't remember why specifically I nuked the var_file to begin with but it does seem unnecessary and overly complex to have two files with largely the same info. Not to mention the hidden magic it's injecting into the packer build which is less than ideal. Need to review later but for now we can at least get builds green.

Signed-off-by: Seth Thomas <sthomas@chef.io>