### PR TITLE
Refactor for Vagrant Cloud

### DIFF
--- a/bento-ya.gemspec
+++ b/bento-ya.gemspec
@@ -22,7 +22,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.3.1"
 
   gem.add_dependency 'rake', '~> 11.2'
-  gem.add_dependency 'test-kitchen', '~> 1.14'
-  gem.add_dependency 'aws-sdk', '~> 2.6'
   gem.add_dependency 'buildkit', '~> 0.4'
 end

--- a/lib/bento/build_remote.rb
+++ b/lib/bento/build_remote.rb
@@ -40,6 +40,10 @@ class BuildRemoteRunner
     "v1/organizations/#{org}"
   end
 
+  def bento_upload
+    "1"
+  end
+
   def build(platform, version, arch, provider, bento_version, dry_run)
     plat =  platform.include?('omnios') ? "#{platform}-#{version}" : "#{platform}-#{version}-#{arch}"
     atlas_name = /(.*)64/.match(arch) ? plat.chomp("-#{arch}") : plat

--- a/lib/bento/buildmetadata.rb
+++ b/lib/bento/buildmetadata.rb
@@ -15,11 +15,11 @@ class BuildMetadata
       version:          version,
       build_timestamp:  build_timestamp,
       git_revision:     git_revision,
-      #git_status:       git_clean? ? "clean" : "dirty"
+      git_status:       git_clean? ? "clean" : "dirty",
       box_basename:     box_basename,
       template:         template_vars.fetch("template", UNKNOWN),
-      cpus:             cpus.to_s,
-      memory:           memory.to_s,
+      packer:           packer_ver,
+      vagrant:          vagrant_ver,
     }
   end
 
@@ -66,5 +66,17 @@ class BuildMetadata
     merged_vars.fetch("version", "#{UNKNOWN}.TIMESTAMP").
       rpartition(".").first.concat(".#{build_timestamp}")
     end
+  end
+
+  def packer_ver
+    cmd = Mixlib::ShellOut.new("packer --version")
+    cmd.run_command
+    cmd.stdout.split("\n")[0]
+  end
+
+  def vagrant_ver
+    cmd = Mixlib::ShellOut.new("vagrant --version")
+    cmd.run_command
+    cmd.stdout.split(' ')[1]
   end
 end

--- a/lib/bento/cli.rb
+++ b/lib/bento/cli.rb
@@ -57,6 +57,10 @@ class Options
       options.version = ARGV[1]
     }
 
+    md_json_argv_proc = proc { |options|
+      options.md_json = ARGV[0]
+    }
+
     subcommand = {
       help: {
         parser: OptionParser.new {},
@@ -153,7 +157,7 @@ class Options
         parser: OptionParser.new { |opts|
           opts.banner = "Usage: #{NAME} upload"
         },
-        argv: box_version_argv_proc
+        argv: md_json_argv_proc
       },
       release: {
         class: ReleaseRunner,

--- a/lib/bento/cli.rb
+++ b/lib/bento/cli.rb
@@ -94,8 +94,16 @@ class Options
             options.mirror = opt
           end
 
-          opts.on("-H", "--headless", "Run providers as headless") do |opt|
-            options.headless = opt
+          opts.on("-C cpus", "--cpus CPUS", "# of CPUs per provider") do |opt|
+            options.cpus = opt
+          end
+
+          opts.on("-M MEMORY", "--memory MEMORY", "Memory (MB) per provider") do |opt|
+            options.mem = opt
+          end
+
+          opts.on("-H", "--headed", "Display provider UI windows") do |opt|
+            options.headed = opt
           end
 
           opts.on("-v VERSION", "--version VERSION", "Override the version set in the template") do |opt|

--- a/lib/bento/common.rb
+++ b/lib/bento/common.rb
@@ -36,7 +36,7 @@ module Common
     metadata['name'] = json['name']
     metadata['version'] = json['version']
     metadata['box_basename'] = json['box_basename']
-    metadata['tool_versions'] = json['box_basename']
+    metadata['tool_versions'] = json['tool_versions']
     metadata['providers'] = Hash.new
     json['providers'].each do |provider|
       metadata['providers'][provider['name']] = provider.reject { |k, _| k == 'name' }
@@ -50,22 +50,6 @@ module Common
 
   def compute_metadata_files
     `ls builds/*.json`.split("\n")
-  end
-
-  def atlas_api
-    @atlas_api ||= 'https://atlas.hashicorp.com/api/v1'
-  end
-
-  def atlas_org
-    @atlas_org ||= ENV['ATLAS_ORG']
-  end
-
-  def atlas_token
-    @atlas_token ||= ENV['ATLAS_TOKEN']
-  end
-
-  def bento_upload
-    "1"
   end
 
   def bento_version

--- a/lib/bento/common.rb
+++ b/lib/bento/common.rb
@@ -36,7 +36,7 @@ module Common
     metadata['name'] = json['name']
     metadata['version'] = json['version']
     metadata['box_basename'] = json['box_basename']
-    metadata['tool_versions'] = json['tool_versions']
+    metadata['tools'] = json['tools']
     metadata['providers'] = Hash.new
     json['providers'].each do |provider|
       metadata['providers'][provider['name']] = provider.reject { |k, _| k == 'name' }
@@ -56,14 +56,6 @@ module Common
     @bento_version ||= ENV['BENTO_VERSION']
   end
 
-  def cpus
-    1
-  end
-
-  def memory
-    1024
-  end
-
   def builds
     YAML.load(File.read("builds.yml"))
   end
@@ -71,40 +63,5 @@ module Common
   def private_box?(boxname)
     proprietary_os_list = %w(macosx sles solaris windows)
     proprietary_os_list.any? { |p| boxname.include?(p) }
-  end
-
-  def tool_versions
-    tool_versions = Hash.new
-    path = File.join('/Applications/VMware\ Fusion.app/Contents/Library')
-    fusion_cmd = File.join(path, "vmware-vmx -v")
-    ver_hash = {
-      packer: "packer --version",
-      vagrant: "vagrant --version",
-      parallels: "prlctl --version",
-      virtualbox: "VBoxManage --version",
-      vmware_fusion: fusion_cmd
-    }
-    ver_hash.each do |tool, command|
-      cmd = Mixlib::ShellOut.new(command)
-      begin
-        cmd.run_command
-        case tool
-        when /parallels/
-          ver = cmd.stdout.split(' ')[2]
-        when /fusion/
-          ver = cmd.stderr.split(' ')[5]
-        when /vagrant/
-          ver = cmd.stdout.split(' ')[1]
-        when /virtualbox/
-          ver = cmd.stdout.split('r')[0]
-        else
-          ver = cmd.stdout.split("\n")[0]
-        end
-        tool_versions[tool] = ver
-      rescue
-        tool_versions[tool] = 'None'
-      end
-    end
-    tool_versions
   end
 end

--- a/lib/bento/delete.rb
+++ b/lib/bento/delete.rb
@@ -1,9 +1,9 @@
 require 'bento/common'
-require 'bento/httpstuff'
+require 'bento/vagrantcloud'
 
 class DeleteRunner
   include Common
-  include HttpStuff
+  include VgCloud
 
   attr_reader :boxname, :version
 
@@ -15,24 +15,8 @@ class DeleteRunner
   def start
     banner("Starting Delete...")
     time = Benchmark.measure do
-      delete_version(boxname, version)
+      box_delete_version(boxname, version)
     end
     banner("Delete finished in #{duration(time.real)}.")
-  end
-
-  private
-
-  def delete_version(boxname, version)
-    banner("Deleting version #{version} of box #{boxname}")
-    req = request('delete', "#{atlas_api}/box/#{atlas_org}/#{boxname}/version/#{version}", { 'access_token' => atlas_token }, { 'Content-Type' => 'application/json' })
-
-    case req.code
-    when '200'
-      banner("Version #{version} of box #{boxname} has been successfully deleted")
-    when '404'
-      warn("No box exists for this version")
-    else
-      warn("Something went wrong #{req.code}")
-    end
   end
 end

--- a/lib/bento/release.rb
+++ b/lib/bento/release.rb
@@ -1,9 +1,9 @@
 require 'bento/common'
-require 'mixlib/shellout'
+require 'bento/vagrantcloud'
 
 class ReleaseRunner
   include Common
-  include HttpStuff
+  include VgCloud
 
   attr_reader :boxname, :version
 
@@ -15,32 +15,8 @@ class ReleaseRunner
   def start
     banner("Starting Release...")
     time = Benchmark.measure do
-      release_version(boxname, version)
+      box_release_version(boxname, version)
     end
     banner("Release finished in #{duration(time.real)}.")
-  end
-
-  private
-
-  def release_version(boxname, version)
-    case status(boxname, version)
-    when 'unreleased'
-      banner("Releasing version #{version} of box #{boxname}")
-      req = request('put', "#{atlas_api}/box/#{atlas_org}/#{boxname}/version/#{version}/release", { 'access_token' => atlas_token }, { 'Content-Type' => 'application/json' })
-      if req.code == '200'
-        banner("Version #{version} of box #{boxname} has been successfully released")
-      else
-        warn("Something went wrong #{req.code}")
-      end
-    when 'active'
-      banner("Version #{version} of box #{boxname} has already been released - nothing to do")
-    else
-      warn("Unexpected status retrieved from Atlas")
-    end
-  end
-
-  def status(boxname, version)
-    req = request('get', "#{atlas_api}/box/#{atlas_org}/#{boxname}/version/#{version}", { 'access_token' => atlas_token }, { 'Content-Type' => 'application/json' })
-    status = JSON.parse(req.body)['status']
   end
 end

--- a/lib/bento/revoke.rb
+++ b/lib/bento/revoke.rb
@@ -1,9 +1,9 @@
 require 'bento/common'
-require 'mixlib/shellout'
+require 'bento/vagrantcloud'
 
 class RevokeRunner
   include Common
-  include HttpStuff
+  include VgCloud
 
   attr_reader :boxname, :version
 
@@ -15,20 +15,8 @@ class RevokeRunner
   def start
     banner("Starting Revoke...")
     time = Benchmark.measure do
-      revoke_version(boxname, version)
+      box_revoke_version(boxname, version)
     end
     banner("Revoke finished in #{duration(time.real)}.")
-  end
-
-  private
-
-  def revoke_version(boxname, version)
-    banner("Revoking version #{version} of box #{boxname}")
-    req = request('put', "#{atlas_api}/box/#{atlas_org}/#{boxname}/version/#{version}/revoke", { 'access_token' => atlas_token }, { 'Content-Type' => 'application/json' })
-    if req.code == '200'
-      banner("Version #{version} of box #{boxname} has been successfully revoked")
-    else
-      banner("Something went wrong #{req.code}")
-    end
   end
 end

--- a/lib/bento/upload.rb
+++ b/lib/bento/upload.rb
@@ -1,118 +1,27 @@
-require 'aws-sdk'
 require 'bento/common'
+require 'bento/vagrantcloud'
 
 class UploadRunner
   include Common
-  include HttpStuff
+  include VgCloud
 
-  attr_reader :templates
+  attr_reader :md_json
 
   def initialize(opts)
-    @templates = opts.templates
+    @md_json = opts.md_json
   end
 
   def start
     banner("Starting uploads...")
     time = Benchmark.measure do
-      metadata_files.each do |file|
-        md = box_metadata(file)
-        create_box(md['name'])
-        create_box_version(md['name'], md['version'], file)
-        create_providers(md['name'], md['version'], md['providers'].keys)
-        upload_to_atlas(md['name'], md['version'], md['providers'])
-        #upload_to_s3(md['name'], md['version'], md['providers'])
+      if md_json.nil?
+        metadata_files.each do |md_file|
+          box_upload(md_file)
+        end
+      else
+        box_upload(md_json)
       end
     end
     banner("Atlas uploads finished in #{duration(time.real)}.")
-  end
-
-  private
-
-  def create_box(boxname)
-    req = request('get', "#{atlas_api}/box/#{atlas_org}/#{boxname}", { 'box[username]' => atlas_org, 'access_token' => atlas_token } )
-    if req.code.eql?('404')
-      if private_box?(boxname)
-        banner("Creating the private box #{boxname} in Atlas.")
-        req = request('post', "#{atlas_api}/boxes", { 'box[name]' => boxname, 'box[username]' => atlas_org, 'access_token' => atlas_token }, { 'Content-Type' => 'application/json' } )
-      else
-        banner("Creating the box #{boxname} in Atlas.")
-        req = request('post', "#{atlas_api}/boxes", { 'box[name]' => boxname, 'box[username]' => atlas_org, 'access_token' => atlas_token }, { 'Content-Type' => 'application/json' } )
-        make_public(boxname)
-      end
-    else
-      banner("The box #{boxname} exists in Atlas, continuing...")
-    end
-  end
-
-  def make_public(boxname)
-    banner("Making #{boxname} public")
-    req = request('put', "#{atlas_api}/box/#{atlas_org}/#{boxname}", { 'box[is_private]' => false, 'access_token' => atlas_token }, { 'Content-Type' => 'application/json' } )
-    banner("#{boxname} successfully made public") if req.code == '200'
-  end
-
-  def create_box_version(boxname, version, md_json)
-		payload = { 
-	  	'version[version]' => version,
-	  	'access_token' => atlas_token,
-		'version[description]' => File.read(md_json)
-		}
-    req = request('post', "#{atlas_api}/box/#{atlas_org}/#{boxname}/versions", payload, { 'Content-Type' => 'application/json' } ) 
-
-    banner("Created box version #{boxname} #{version}.") if req.code == '200'
-    banner("Box version #{boxname} #{version} already exists, continuing.") if req.code == '422'
-  end
-
-  def create_providers(boxname, version, provider_names)
-    provider_names.each do |provider|
-      banner("Creating provider #{provider} for #{boxname} #{version}")
-      req = request('post', "#{atlas_api}/box/#{atlas_org}/#{boxname}/version/#{version}/providers", { 'provider[name]' => provider, 'access_token' => atlas_token }, { 'Content-Type' => 'application/json' }  )
-      banner("Created #{provider} for #{boxname} #{version}") if req.code == '200'
-      banner("Provider #{provider} for #{boxname} #{version} already exists, continuing.") if req.code == '422'
-    end
-  end
-
-  def upload_to_atlas(boxname, version, providers)
-    providers.each do |provider, provider_data|
-      boxfile = provider_data['file']
-      req = request('get', "#{atlas_api}/box/#{atlas_org}/#{boxname}/version/#{version}/provider/#{provider}/upload?access_token=#{atlas_token}")
-      upload_path = JSON.parse(req.body)['upload_path']
-      token = JSON.parse(req.body)['token']
-
-      banner("Atlas: Uploading #{boxfile}")
-      info("Name: #{boxname}")
-      info("Version: #{version}")
-      info("Provider: #{provider}")
-      info("Upload Path: #{upload_path}")
-      upload_request = request('put', upload_path, File.open("builds/#{boxfile}"))
-
-      req = request('get', "#{atlas_api}/box/#{atlas_org}/#{boxname}/version/#{version}/provider/#{provider}?access_token=#{atlas_token}")
-      hosted_token = JSON.parse(req.body)['hosted_token']
-
-      if token == hosted_token
-        banner("Successful upload of box #{boxfile}")
-      else
-        banner("Failed upload due to non-matching tokens of box #{boxfile} to atlas box: #{boxname}, version: #{version}, provider: #{provider}")
-        warn("Code: #{req.code}")
-        warn("Body: #{req.body}")
-      end
-    end
-
-    def upload_to_s3(boxname, version, providers)
-      providers.each do |provider, provider_data|
-        boxfile = provider_data['file']
-        provider = 'vmware' if provider == 'vmware_desktop'
-        box_path = "vagrant/#{provider}/opscode_#{boxname}_chef-provisionerless.box"
-        credentials = Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
-
-        s3 = Aws::S3::Resource.new(credentials: credentials, endpoint: s3_endpoint)
-        banner("S3: Uploading #{boxfile}")
-        info("Name: #{boxname}")
-        info("Version: #{version}")
-        info("Provider: #{provider}")
-        s3_object = s3.bucket(s3_bucket).object(box_path)
-        s3_object.upload_file("builds/#{boxfile}", acl:'public-read')
-        banner("Upload Path: #{s3_object.public_url}")
-      end
-    end
   end
 end

--- a/lib/bento/vagrantcloud.rb
+++ b/lib/bento/vagrantcloud.rb
@@ -1,0 +1,138 @@
+require 'bento/common'
+require 'bento/httpstuff'
+
+module VgCloud
+  include Common
+  include HttpStuff
+
+  def vgc_api
+    @vgc_api ||= 'https://vagrantcloud.com/api/v1'
+  end
+
+  def vgc_org
+    @vgc_org ||= ENV['ATLAS_ORG']
+  end
+
+  def vgc_token
+    @vgc_token ||= ENV['ATLAS_TOKEN']
+  end
+
+  def box_create(boxname)
+    req = request('get', "#{vgc_api}/box/#{vgc_org}/#{boxname}", { 'box[username]' => vgc_org, 'access_token' => vgc_token } )
+    if req.code.eql?('404')
+      req = request('post', "#{vgc_api}/boxes", { 'box[name]' => boxname, 'box[username]' => vgc_org, 'access_token' => vgc_token }, { 'Content-Type' => 'application/json' } )
+      box_set_public(boxname) unless private_box?(boxname)
+    else
+      banner("The box #{boxname} exists in Atlas, continuing...")
+    end
+  end
+
+  def box_create_providers(boxname, version, provider_names)
+    provider_names.each do |provider|
+      banner("Creating provider #{provider} for #{boxname} #{version}")
+      req = request('post', "#{vgc_api}/box/#{vgc_org}/#{boxname}/version/#{version}/providers", { 'provider[name]' => provider, 'access_token' => vgc_token }, { 'Content-Type' => 'application/json' }  )
+      banner("Created #{provider} for #{boxname} #{version}") if req.code == '200'
+      banner("Provider #{provider} for #{boxname} #{version} already exists, continuing.") if req.code == '422'
+    end
+  end
+
+  def box_create_version(boxname, version, md_json)
+    payload = {
+      'version[version]' => version,
+      'access_token' => vgc_token,
+      'version[description]' => File.read(md_json)
+    }
+    req = request('post', "#{vgc_api}/box/#{vgc_org}/#{boxname}/versions", payload, { 'Content-Type' => 'application/json' } )
+
+    banner("Created box version #{boxname} #{version}.") if req.code == '200'
+    banner("Box version #{boxname} #{version} already exists, continuing.") if req.code == '422'
+  end
+
+  def box_delete_version(boxname, version)
+    banner("Deleting version #{version} of box #{boxname}")
+    req = request('delete', "#{vgc_api}/box/#{vgc_org}/#{boxname}/version/#{version}", { 'access_token' => vgc_token }, { 'Content-Type' => 'application/json' })
+
+    case req.code
+    when '200'
+      banner("Version #{version} of box #{boxname} has been successfully deleted")
+    when '404'
+      warn("No box exists for this version")
+    else
+      warn("Something went wrong #{req.code}")
+    end
+  end
+
+  def box_release_version(boxname, version)
+    case status(boxname, version)
+    when 'unreleased'
+      banner("Releasing version #{version} of box #{boxname}")
+      req = request('put', "#{vgc_api}/box/#{vgc_org}/#{boxname}/version/#{version}/release", { 'access_token' => vgc_token }, { 'Content-Type' => 'application/json' })
+      if req.code == '200'
+        banner("Version #{version} of box #{boxname} has been successfully released")
+      else
+        warn("Something went wrong #{req.code}")
+      end
+    when 'active'
+      banner("Version #{version} of box #{boxname} has already been released - nothing to do")
+    else
+      warn("Unexpected status retrieved from Atlas")
+    end
+  end
+
+  def box_revoke_version(boxname, version)
+    banner("Revoking version #{version} of box #{boxname}")
+    req = request('put', "#{vgc_api}/box/#{vgc_org}/#{boxname}/version/#{version}/revoke", { 'access_token' => vgc_token }, { 'Content-Type' => 'application/json' })
+    if req.code == '200'
+      banner("Version #{version} of box #{boxname} has been successfully revoked")
+    else
+      banner("Something went wrong #{req.code}")
+    end
+  end
+
+  def box_status(boxname, version)
+    req = request('get', "#{vgc_api}/box/#{vgc_org}/#{boxname}/version/#{version}", { 'access_token' => vgc_token }, { 'Content-Type' => 'application/json' })
+    status = JSON.parse(req.body)['status']
+  end
+
+  def box_set_public(boxname)
+    banner("Making #{boxname} public")
+    req = request('put', "#{vgc_api}/box/#{vgc_org}/#{boxname}", { 'box[is_private]' => false, 'access_token' => vgc_token }, { 'Content-Type' => 'application/json' } )
+    banner("#{boxname} successfully made public") if req.code == '200'
+  end
+
+  def box_upload(md_file)
+    md = box_metadata(md_file)
+    boxname = md['name']
+    version = md['version']
+    providers = md['providers']
+
+    box_create(boxname)
+    box_create_version(boxname, version, md_file)
+    box_create_providers(boxname, version, providers.keys)
+
+    providers.each do |provider, provider_data|
+      boxfile = provider_data['file']
+      req = request('get', "#{vgc_api}/box/#{vgc_org}/#{boxname}/version/#{version}/provider/#{provider}/upload?access_token=#{vgc_token}")
+      upload_path = JSON.parse(req.body)['upload_path']
+      token = JSON.parse(req.body)['token']
+
+      banner("Vagrant Cloud: Uploading #{boxfile}")
+      info("Name: #{boxname}")
+      info("Version: #{version}")
+      info("Provider: #{provider}")
+
+      upload_request = request('put', upload_path, File.open("builds/#{boxfile}"))
+
+      req = request('get', "#{vgc_api}/box/#{vgc_org}/#{boxname}/version/#{version}/provider/#{provider}?access_token=#{vgc_token}")
+      hosted_token = JSON.parse(req.body)['hosted_token']
+
+      if token == hosted_token
+        banner("Successful upload of box #{boxfile}")
+      else
+        banner("Failed upload due to non-matching tokens of box #{boxfile} to atlas box: #{boxname}, version: #{version}, provider: #{provider}")
+        warn("Code: #{req.code}")
+        warn("Body: #{req.body}")
+      end
+    end
+  end
+end

--- a/templates/kitchen.yml.erb
+++ b/templates/kitchen.yml.erb
@@ -1,0 +1,18 @@
+---
+provisioner:
+  name: <%= @provisioner %>
+
+platforms:
+<% @providers.each do |k,v| -%>
+- name: <%= @boxname + '-' + k %>
+  driver:
+    name: vagrant
+    provider: <%= k %>
+    box: bento-<%= @boxname %>
+    box_url: file://<%= ENV['PWD'] %>/builds/<%= v['file'] %>
+    synced_folders:
+      - [".", "/vagrant", "disabled: <%= @share_disabled %>"]
+
+<% end -%>
+suites:
+- name: default

--- a/templates/kitchen.yml.erb
+++ b/templates/kitchen.yml.erb
@@ -7,7 +7,15 @@ platforms:
 - name: <%= @boxname + '-' + k %>
   driver:
     name: vagrant
+<% if k == 'vmware' -%>
+<% if RUBY_PLATFORM.match(/darwin/) -%>
+    provider: <%= k + '_fusion' %>
+<% else -%>
+    provider: <%= k + '_workstation' %>
+<% end -%>
+<% else -%>
     provider: <%= k %>
+<% end -%>
     box: bento-<%= @boxname %>
     box_url: file://<%= ENV['PWD'] %>/builds/<%= v['file'] %>
     synced_folders:


### PR DESCRIPTION
Refactor initiated by Vagrant Cloud changes
- brings kitchen template internal instead of as part of bento repo
- remove unneeded deps
- headless by default
- DRYing up and re-organizing